### PR TITLE
fix #106

### DIFF
--- a/src/sites/common/text-parser.jade
+++ b/src/sites/common/text-parser.jade
@@ -21,7 +21,7 @@
 
 	function analyzeMentions(text) {
 		'use strict';
-		return text.replace(/@([a-zA-Z0-9\-]+)/g, function(arg, screenName) {
+		return text.replace(/(^|\s)@([a-zA-Z0-9\-]+)/g, function(arg, _, screenName) {
 			return '<a href="' + config.url + '/' + screenName + '" class="mention" data-user-card="' + screenName + '">@' + screenName + '</a>';
 		});
 	}


### PR DESCRIPTION
メンションのパースをハッシュタグと同一にした
この変更により、連鎖したメンション(`@hoge@piyo`, etc..)はメンションとして認識されなくなる